### PR TITLE
Add TryGetSymbolinfo to ISymbolHandler

### DIFF
--- a/src/PlcInterface.Abstraction/ISymbolHandler.cs
+++ b/src/PlcInterface.Abstraction/ISymbolHandler.cs
@@ -21,4 +21,12 @@ public interface ISymbolHandler
     /// <param name="ioName">The tag name.</param>
     /// <returns>The found <see cref="ISymbolInfo"/>.</returns>
     ISymbolInfo GetSymbolinfo(string ioName);
+
+    /// <summary>
+    /// Try to get the <see cref="ISymbolInfo"/>.
+    /// </summary>
+    /// <param name="ioName">The tag name.</param>
+    /// <param name="symbolInfo">The found <see cref="ISymbolInfo"/>.</param>
+    /// <returns><see langword="true"/> when the symbol was found else <see langword="false"/>.</returns>
+    bool TryGetSymbolinfo(string ioName, out ISymbolInfo? symbolInfo);
 }

--- a/src/PlcInterface.Ads/IAdsSymbolHandler.cs
+++ b/src/PlcInterface.Ads/IAdsSymbolHandler.cs
@@ -11,4 +11,12 @@ public interface IAdsSymbolHandler : ISymbolHandler
     /// <param name="ioName">The tag name.</param>
     /// <returns>The found <see cref="ISymbolInfo"/>.</returns>
     new IAdsSymbolInfo GetSymbolinfo(string ioName);
+
+    /// <summary>
+    /// Try to get the <see cref="IAdsSymbolInfo"/>.
+    /// </summary>
+    /// <param name="ioName">The tag name.</param>
+    /// <param name="symbolInfo">The found <see cref="IAdsSymbolInfo"/>.</param>
+    /// <returns><see langword="true"/> when the symbol was found else <see langword="false"/>.</returns>
+    bool TryGetSymbolinfo(string ioName, out IAdsSymbolInfo? symbolInfo);
 }

--- a/src/PlcInterface.Ads/SymbolHandler.cs
+++ b/src/PlcInterface.Ads/SymbolHandler.cs
@@ -70,12 +70,32 @@ public class SymbolHandler : IAdsSymbolHandler, IDisposable
     /// <inheritdoc/>
     public IAdsSymbolInfo GetSymbolinfo(string ioName)
     {
-        if (!allSymbols.TryGetValue(ioName.ToLower(CultureInfo.InvariantCulture), out var value))
+        if (TryGetSymbolinfo(ioName, out var symbolInfo) && symbolInfo != null)
         {
-            throw new SymbolException($"{ioName} Does not excist in the PLC");
+            return symbolInfo;
         }
 
-        return value;
+        throw new SymbolException($"{ioName} Does not excist in the PLC");
+    }
+
+    /// <inheritdoc/>
+    bool ISymbolHandler.TryGetSymbolinfo(string ioName, out ISymbolInfo? symbolInfo)
+    {
+        var result = TryGetSymbolinfo(ioName, out var symbolInfoResult);
+        symbolInfo = symbolInfoResult;
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetSymbolinfo(string ioName, out IAdsSymbolInfo? symbolInfo)
+    {
+        if (allSymbols.TryGetValue(ioName.ToLower(CultureInfo.InvariantCulture), out symbolInfo))
+        {
+            return true;
+        }
+
+        logger.LogError("{IoName} Does not excist in the PLC", ioName);
+        return false;
     }
 
     /// <summary>

--- a/src/PlcInterface.OpcUa/SymbolHandler.cs
+++ b/src/PlcInterface.OpcUa/SymbolHandler.cs
@@ -59,12 +59,26 @@ public class SymbolHandler : IOpcSymbolHandler, IDisposable
     /// <inheritdoc/>
     public ISymbolInfo GetSymbolinfo(string ioName)
     {
-        if (!allSymbols.TryGetValue(ioName.ToLower(CultureInfo.InvariantCulture), out var value))
+        if (TryGetSymbolinfo(ioName, out var symbolInfo) && symbolInfo != null)
         {
-            throw new SymbolException($"{ioName} Does not excist in the PLC");
+            return symbolInfo;
         }
 
-        return value;
+        throw new SymbolException($"{ioName} Does not excist in the PLC");
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetSymbolinfo(string ioName, out ISymbolInfo? symbolInfo)
+    {
+        if (allSymbols.TryGetValue(ioName.ToLower(CultureInfo.InvariantCulture), out var symbolInfoResult))
+        {
+            symbolInfo = symbolInfoResult;
+            return true;
+        }
+
+        logger.LogError("{IoName} Does not excist in the PLC", ioName);
+        symbolInfo = null;
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
Add a method that doesn't throw when the symbol can't be found.
this fixes the problem that when you start monitoring before connection has been made