### PR TITLE
Try get symbol implementation

### DIFF
--- a/src/PlcInterface.Abstraction/ISymbolHandler.cs
+++ b/src/PlcInterface.Abstraction/ISymbolHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace PlcInterface;
 
@@ -28,5 +29,5 @@ public interface ISymbolHandler
     /// <param name="ioName">The tag name.</param>
     /// <param name="symbolInfo">The found <see cref="ISymbolInfo"/>.</param>
     /// <returns><see langword="true"/> when the symbol was found else <see langword="false"/>.</returns>
-    bool TryGetSymbolinfo(string ioName, out ISymbolInfo? symbolInfo);
+    bool TryGetSymbolinfo(string ioName, [MaybeNullWhen(false)] out ISymbolInfo symbolInfo);
 }

--- a/src/PlcInterface.Abstraction/ISymbolHandler.cs
+++ b/src/PlcInterface.Abstraction/ISymbolHandler.cs
@@ -21,4 +21,12 @@ public interface ISymbolHandler
     /// <param name="ioName">The tag name.</param>
     /// <returns>The found <see cref="ISymbolInfo"/>.</returns>
     ISymbolInfo GetSymbolinfo(string ioName);
+
+    /// <summary>
+    /// Try to get the <see cref="ISymbolInfo"/>.
+    /// </summary>
+    /// <param name="ioName">The tag name.</param>
+    /// <param name="symbolInfo">The found <see cref="ISymbolInfo"/>.</param>
+    /// <returns><see langword="true"/> when the symbol was found else <see langword="false"/>.</returns>
+    bool TryGetSymbolinfo(string ioName, out ISymbolInfo? symbolInfo);
 }

--- a/src/PlcInterface.Ads/DisposableMonitorItem.cs
+++ b/src/PlcInterface.Ads/DisposableMonitorItem.cs
@@ -53,9 +53,8 @@ internal sealed class DisposableMonitorItem : IDisposable
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "MA0032:Use an overload with a CancellationToken argument", Justification = "Dont need a cancelation token.")]
     public void Update(IAdsSymbolHandler symbolHandler, ISubject<IMonitorResult> symbolStream, IAdsTypeConverter typeConverter)
     {
-        var symbolInfo = symbolHandler.GetSymbolinfo(name);
-
-        if (symbolInfo.Symbol is IValueSymbol valueSymbol
+        if (symbolHandler.TryGetSymbolinfo(name, out var symbolInfo)
+            && symbolInfo.Symbol is IValueSymbol valueSymbol
             && valueSymbol.Connection != null
             && valueSymbol.Connection.IsConnected)
         {

--- a/src/PlcInterface.Ads/IAdsSymbolHandler.cs
+++ b/src/PlcInterface.Ads/IAdsSymbolHandler.cs
@@ -1,4 +1,6 @@
-﻿namespace PlcInterface.Ads;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace PlcInterface.Ads;
 
 /// <summary>
 /// The Ads implementation of a <see cref="ISymbolHandler"/>.
@@ -18,5 +20,5 @@ public interface IAdsSymbolHandler : ISymbolHandler
     /// <param name="ioName">The tag name.</param>
     /// <param name="symbolInfo">The found <see cref="IAdsSymbolInfo"/>.</param>
     /// <returns><see langword="true"/> when the symbol was found else <see langword="false"/>.</returns>
-    bool TryGetSymbolinfo(string ioName, out IAdsSymbolInfo? symbolInfo);
+    bool TryGetSymbolinfo(string ioName, [MaybeNullWhen(false)] out IAdsSymbolInfo symbolInfo);
 }

--- a/src/PlcInterface.Ads/IAdsSymbolHandler.cs
+++ b/src/PlcInterface.Ads/IAdsSymbolHandler.cs
@@ -11,4 +11,12 @@ public interface IAdsSymbolHandler : ISymbolHandler
     /// <param name="ioName">The tag name.</param>
     /// <returns>The found <see cref="ISymbolInfo"/>.</returns>
     new IAdsSymbolInfo GetSymbolinfo(string ioName);
+
+    /// <summary>
+    /// Try to get the <see cref="IAdsSymbolInfo"/>.
+    /// </summary>
+    /// <param name="ioName">The tag name.</param>
+    /// <param name="symbolInfo">The found <see cref="IAdsSymbolInfo"/>.</param>
+    /// <returns><see langword="true"/> when the symbol was found else <see langword="false"/>.</returns>
+    bool TryGetSymbolinfo(string ioName, out IAdsSymbolInfo? symbolInfo);
 }

--- a/src/PlcInterface.Ads/SymbolHandler.cs
+++ b/src/PlcInterface.Ads/SymbolHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO.Abstractions;
 using System.Linq;
@@ -79,7 +80,7 @@ public class SymbolHandler : IAdsSymbolHandler, IDisposable
     }
 
     /// <inheritdoc/>
-    bool ISymbolHandler.TryGetSymbolinfo(string ioName, out ISymbolInfo? symbolInfo)
+    bool ISymbolHandler.TryGetSymbolinfo(string ioName, [MaybeNullWhen(false)] out ISymbolInfo symbolInfo)
     {
         var result = TryGetSymbolinfo(ioName, out var symbolInfoResult);
         symbolInfo = symbolInfoResult;
@@ -87,7 +88,7 @@ public class SymbolHandler : IAdsSymbolHandler, IDisposable
     }
 
     /// <inheritdoc/>
-    public bool TryGetSymbolinfo(string ioName, out IAdsSymbolInfo? symbolInfo)
+    public bool TryGetSymbolinfo(string ioName, [MaybeNullWhen(false)] out IAdsSymbolInfo symbolInfo)
     {
         if (allSymbols.TryGetValue(ioName.ToLower(CultureInfo.InvariantCulture), out symbolInfo))
         {

--- a/src/PlcInterface.Ads/SymbolHandler.cs
+++ b/src/PlcInterface.Ads/SymbolHandler.cs
@@ -70,12 +70,32 @@ public class SymbolHandler : IAdsSymbolHandler, IDisposable
     /// <inheritdoc/>
     public IAdsSymbolInfo GetSymbolinfo(string ioName)
     {
-        if (!allSymbols.TryGetValue(ioName.ToLower(CultureInfo.InvariantCulture), out var value))
+        if (TryGetSymbolinfo(ioName, out var symbolInfo) && symbolInfo != null)
         {
-            throw new SymbolException($"{ioName} Does not excist in the PLC");
+            return symbolInfo;
         }
 
-        return value;
+        throw new SymbolException($"{ioName} Does not excist in the PLC");
+    }
+
+    /// <inheritdoc/>
+    bool ISymbolHandler.TryGetSymbolinfo(string ioName, out ISymbolInfo? symbolInfo)
+    {
+        var result = TryGetSymbolinfo(ioName, out var symbolInfoResult);
+        symbolInfo = symbolInfoResult;
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetSymbolinfo(string ioName, out IAdsSymbolInfo? symbolInfo)
+    {
+        if (allSymbols.TryGetValue(ioName.ToLower(CultureInfo.InvariantCulture), out symbolInfo))
+        {
+            return true;
+        }
+
+        logger.LogError("{IoName} Does not excist in the PLC", ioName);
+        return false;
     }
 
     /// <summary>

--- a/src/PlcInterface.OpcUa/Monitor.cs
+++ b/src/PlcInterface.OpcUa/Monitor.cs
@@ -273,8 +273,7 @@ public class Monitor : IOpcMonitor, IDisposable
 
         public void UpdateMonitoredItem(ISymbolHandler symbolHandler)
         {
-            var symbol = symbolHandler.GetSymbolinfo(name);
-            if (symbol != null)
+            if (symbolHandler.TryGetSymbolinfo(name, out var symbol))
             {
                 var symbolInfo = symbol.ConvertAndValidate();
                 MonitoredItem.StartNodeId = symbolInfo.Handle;

--- a/src/PlcInterface.OpcUa/SymbolHandler.cs
+++ b/src/PlcInterface.OpcUa/SymbolHandler.cs
@@ -59,12 +59,26 @@ public class SymbolHandler : IOpcSymbolHandler, IDisposable
     /// <inheritdoc/>
     public ISymbolInfo GetSymbolinfo(string ioName)
     {
-        if (!allSymbols.TryGetValue(ioName.ToLower(CultureInfo.InvariantCulture), out var value))
+        if (TryGetSymbolinfo(ioName, out var symbolInfo) && symbolInfo != null)
         {
-            throw new SymbolException($"{ioName} Does not excist in the PLC");
+            return symbolInfo;
         }
 
-        return value;
+        throw new SymbolException($"{ioName} Does not excist in the PLC");
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetSymbolinfo(string ioName, out ISymbolInfo? symbolInfo)
+    {
+        if (allSymbols.TryGetValue(ioName.ToLower(CultureInfo.InvariantCulture), out var symbolInfoResult))
+        {
+            symbolInfo = symbolInfoResult;
+            return true;
+        }
+
+        logger.LogError("{IoName} Does not excist in the PLC", ioName);
+        symbolInfo = null;
+        return false;
     }
 
     /// <summary>

--- a/src/PlcInterface.OpcUa/SymbolHandler.cs
+++ b/src/PlcInterface.OpcUa/SymbolHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reactive.Disposables;
 using Microsoft.Extensions.Logging;
@@ -68,7 +69,7 @@ public class SymbolHandler : IOpcSymbolHandler, IDisposable
     }
 
     /// <inheritdoc/>
-    public bool TryGetSymbolinfo(string ioName, out ISymbolInfo? symbolInfo)
+    public bool TryGetSymbolinfo(string ioName, [MaybeNullWhen(false)] out ISymbolInfo symbolInfo)
     {
         if (allSymbols.TryGetValue(ioName.ToLower(CultureInfo.InvariantCulture), out var symbolInfoResult))
         {

--- a/test/PlcInterface.Ads.Tests/MonitorTests.cs
+++ b/test/PlcInterface.Ads.Tests/MonitorTests.cs
@@ -25,8 +25,9 @@ public class MonitorTests
         _ = valueSymbolMock.SetupGet(x => x.Connection).Returns(twincatConnectionMock.Object);
         var symbolInfoMock = new Mock<IAdsSymbolInfo>();
         _ = symbolInfoMock.SetupGet(x => x.Symbol).Returns(valueSymbolMock.Object);
+        var symbolInfo = symbolInfoMock.Object;
         var symbolHandlerMock = new Mock<IAdsSymbolHandler>();
-        _ = symbolHandlerMock.Setup(x => x.GetSymbolinfo(It.IsAny<string>())).Returns(symbolInfoMock.Object);
+        _ = symbolHandlerMock.Setup(x => x.TryGetSymbolinfo(It.IsAny<string>(), out symbolInfo)).Returns(true);
         var typeConverterMock = new Mock<IAdsTypeConverter>();
         using var monitor = new Monitor(connectionMock.Object, symbolHandlerMock.Object, typeConverterMock.Object, MockHelpers.GetLoggerMock<Monitor>());
         var connectedMock = new Mock<IConnected<IAdsConnection>>();
@@ -55,8 +56,9 @@ public class MonitorTests
         _ = valueSymbolMock.SetupGet(x => x.Connection).Returns(twincatConnectionMock.Object);
         var symbolInfoMock = new Mock<IAdsSymbolInfo>();
         _ = symbolInfoMock.SetupGet(x => x.Symbol).Returns(valueSymbolMock.Object);
+        var symbolInfo = symbolInfoMock.Object;
         var symbolHandlerMock = new Mock<IAdsSymbolHandler>();
-        _ = symbolHandlerMock.Setup(x => x.GetSymbolinfo(It.IsAny<string>())).Returns(symbolInfoMock.Object);
+        _ = symbolHandlerMock.Setup(x => x.TryGetSymbolinfo(It.IsAny<string>(), out symbolInfo)).Returns(true);
         var typeConverterMock = new Mock<IAdsTypeConverter>();
         using var monitor = new Monitor(connectionMock.Object, symbolHandlerMock.Object, typeConverterMock.Object, MockHelpers.GetLoggerMock<Monitor>());
 
@@ -105,8 +107,9 @@ public class MonitorTests
         _ = valueSymbolMock.SetupGet(x => x.Connection).Returns(twincatConnectionMock.Object);
         var symbolInfoMock = new Mock<IAdsSymbolInfo>();
         _ = symbolInfoMock.SetupGet(x => x.Symbol).Returns(valueSymbolMock.Object);
+        var symbolInfo = symbolInfoMock.Object;
         var symbolHandlerMock = new Mock<IAdsSymbolHandler>();
-        _ = symbolHandlerMock.Setup(x => x.GetSymbolinfo(It.Is<string>(x => x.Equals(ioTag, StringComparison.Ordinal)))).Returns(symbolInfoMock.Object);
+        _ = symbolHandlerMock.Setup(x => x.TryGetSymbolinfo(It.IsAny<string>(), out symbolInfo)).Returns(true);
         var typeConverterMock = new Mock<IAdsTypeConverter>();
         using var monitor = new Monitor(connectionMock.Object, symbolHandlerMock.Object, typeConverterMock.Object, MockHelpers.GetLoggerMock<Monitor>());
 
@@ -172,8 +175,9 @@ public class MonitorTests
         _ = valueSymbolMock.SetupGet(x => x.Connection).Returns(twincatConnectionMock.Object);
         var symbolInfoMock = new Mock<IAdsSymbolInfo>();
         _ = symbolInfoMock.SetupGet(x => x.Symbol).Returns(valueSymbolMock.Object);
+        var symbolInfo = symbolInfoMock.Object;
         var symbolHandlerMock = new Mock<IAdsSymbolHandler>();
-        _ = symbolHandlerMock.Setup(x => x.GetSymbolinfo(It.Is<string>(x => x.Equals(ioTag, StringComparison.Ordinal)))).Returns(symbolInfoMock.Object);
+        _ = symbolHandlerMock.Setup(x => x.TryGetSymbolinfo(It.IsAny<string>(), out symbolInfo)).Returns(true);
         var typeConverterMock = new Mock<IAdsTypeConverter>();
         using var monitor = new Monitor(connectionMock.Object, symbolHandlerMock.Object, typeConverterMock.Object, MockHelpers.GetLoggerMock<Monitor>());
 
@@ -202,8 +206,9 @@ public class MonitorTests
         _ = valueSymbolMock.SetupGet(x => x.Connection).Returns(twincatConnectionMock.Object);
         var symbolInfoMock = new Mock<IAdsSymbolInfo>();
         _ = symbolInfoMock.SetupGet(x => x.Symbol).Returns(valueSymbolMock.Object);
+        var symbolInfo = symbolInfoMock.Object;
         var symbolHandlerMock = new Mock<IAdsSymbolHandler>();
-        _ = symbolHandlerMock.Setup(x => x.GetSymbolinfo(It.IsAny<string>())).Returns(symbolInfoMock.Object);
+        _ = symbolHandlerMock.Setup(x => x.TryGetSymbolinfo(It.IsAny<string>(), out symbolInfo)).Returns(true);
         var typeConverterMock = new Mock<IAdsTypeConverter>();
         _ = typeConverterMock.Setup(x => x.Convert(It.IsAny<object>(), It.IsAny<IValueSymbol>())).Returns<object, IValueSymbol>((o, v) => o);
         using var monitor = new Monitor(connectionMock.Object, symbolHandlerMock.Object, typeConverterMock.Object, MockHelpers.GetLoggerMock<Monitor>());

--- a/test/PlcInterface.Opc.IntegrationTests/MonitorTest.cs
+++ b/test/PlcInterface.Opc.IntegrationTests/MonitorTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PlcInterface.OpcUa;
 using PlcInterface.Tests;
@@ -15,8 +14,17 @@ public class MonitorTest : IMonitorTestBase
     private static ReadWrite? readWrite;
     private static SymbolHandler? symbolHandler;
 
+    [ClassCleanup]
+    public static void Disconnect()
+    {
+        connection!.Dispose();
+        symbolHandler!.Dispose();
+        readWrite!.Dispose();
+        monitor!.Dispose();
+    }
+
     [ClassInitialize]
-    public static async Task ConnectAsync(TestContext testContext)
+    public static void Setup(TestContext testContext)
     {
         var connectionsettings = new OPCSettings();
         new DefaultOPCSettingsConfigureOptions().Configure(connectionsettings);
@@ -27,25 +35,21 @@ public class MonitorTest : IMonitorTestBase
         symbolHandler = new SymbolHandler(connection, MockHelpers.GetLoggerMock<SymbolHandler>());
         readWrite = new ReadWrite(connection, symbolHandler, typeConverter, MockHelpers.GetLoggerMock<ReadWrite>());
         monitor = new Monitor(connection, symbolHandler, typeConverter, MockHelpers.GetLoggerMock<Monitor>());
-
-        await connection.ConnectAsync();
-        _ = await connection.GetConnectedClientAsync(TimeSpan.FromSeconds(1));
-    }
-
-    [ClassCleanup]
-    public static void Disconnect()
-    {
-        connection!.Dispose();
-        symbolHandler!.Dispose();
-        readWrite!.Dispose();
-        monitor!.Dispose();
     }
 
     protected override IMonitor GetMonitor()
         => monitor!;
 
-    protected override IPlcConnection GetPLCConnection()
-        => connection!;
+    protected override IPlcConnection GetPLCConnection(bool connected = true)
+    {
+        if (connected)
+        {
+            connection?.Connect();
+            _ = connection?.GetConnectedClient(TimeSpan.FromSeconds(1));
+        }
+
+        return connection!;
+    }
 
     protected override IReadWrite GetReadWrite()
         => readWrite!;

--- a/test/PlcInterface.Tests/ISymbolHandlerTestBase.cs
+++ b/test/PlcInterface.Tests/ISymbolHandlerTestBase.cs
@@ -32,5 +32,36 @@ public abstract class ISymbolHandlerTestBase
         Assert.IsTrue(count > 0);
     }
 
+    [TestMethod]
+    public void TryGetSymbolInfoReturnsFalseWithInvallidData()
+    {
+        // Arrange
+        var symbolHandler = GetSymbolHandler();
+        var ioName = "ANonExcistingSymbol";
+
+        // Act
+        var result = symbolHandler.TryGetSymbolinfo(ioName, out var symbol);
+
+        // Assert
+        Assert.AreEqual(false, result);
+        Assert.IsNull(symbol);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(Settings.GetMonitorData), typeof(Settings), DynamicDataSourceType.Method)]
+    public void TryGetSymbolInfoReturnsTrueWithVallidData(string ioName)
+    {
+        // Arrange
+        var symbolHandler = GetSymbolHandler();
+
+        // Act
+        var result = symbolHandler.TryGetSymbolinfo(ioName, out var symbol);
+
+        // Assert
+        Assert.AreEqual(true, result);
+        Assert.IsNotNull(symbol);
+        Assert.AreEqual(ioName, symbol.Name);
+    }
+
     protected abstract ISymbolHandler GetSymbolHandler();
 }


### PR DESCRIPTION
Add a method that doesn't throw when the symbol can't be found.
this fixes the problem that when you start monitoring before connection has been made