### PR TITLE
Parallize tests except integration monitor and write test

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -65,5 +65,9 @@
         <CaptureTraceOutput>false</CaptureTraceOutput>
         <DeleteDeploymentDirectoryAfterTestRunIsComplete>False</DeleteDeploymentDirectoryAfterTestRunIsComplete>
         <DeploymentEnabled>False</DeploymentEnabled>
+        <Parallelize>
+            <Workers>0</Workers>
+            <Scope>MethodLevel</Scope>
+        </Parallelize>
     </MSTest>
 </RunSettings>

--- a/test/PlcInterface.Ads.IntegrationTests/PlcConnectionTest.cs
+++ b/test/PlcInterface.Ads.IntegrationTests/PlcConnectionTest.cs
@@ -8,13 +8,14 @@ using TwinCAT.Ads;
 namespace PlcInterface.Ads.IntegrationTests;
 
 [TestClass]
-public class PlcConnectionTest : IPlcConnectionTestBase
+public sealed class PlcConnectionTest : IPlcConnectionTestBase, IDisposable
 {
-    private static AdsClient? adsClient;
-    private static PlcConnection? plcConnection;
+    private AdsClient? adsClient;
+    private bool disposed;
+    private PlcConnection? plcConnection;
 
-    [ClassInitialize]
-    public static void ConnectAsync(TestContext testContext)
+    [TestInitialize]
+    public void ConnectAsync()
     {
         var connectionsettings = new AdsPlcConnectionOptions() { AmsNetId = Settings.AmsNetId, Port = Settings.Port };
         adsClient = new AdsClient();
@@ -22,11 +23,20 @@ public class PlcConnectionTest : IPlcConnectionTestBase
         plcConnection = new PlcConnection(MockHelpers.GetOptionsMoq(connectionsettings), MockHelpers.GetLoggerMock<PlcConnection>(), adsClient);
     }
 
-    [ClassCleanup]
-    public static void Disconnect()
+    [TestCleanup]
+    public void Disconnect()
+        => Dispose();
+
+    public void Dispose()
     {
-        plcConnection!.Dispose();
-        adsClient!.Dispose();
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        plcConnection?.Dispose();
+        adsClient?.Dispose();
     }
 
     [TestMethod]
@@ -72,5 +82,8 @@ public class PlcConnectionTest : IPlcConnectionTestBase
     }
 
     protected override IPlcConnection GetPLCConnection()
-        => plcConnection!;
+    {
+        Assert.IsNotNull(plcConnection);
+        return plcConnection;
+    }
 }

--- a/test/PlcInterface.Ads.IntegrationTests/ReadValueTest.cs
+++ b/test/PlcInterface.Ads.IntegrationTests/ReadValueTest.cs
@@ -11,15 +11,16 @@ using TwinCAT.Ads;
 namespace PlcInterface.Ads.IntegrationTests;
 
 [TestClass]
-public class ReadValueTest : IReadValueTestBase
+public sealed class ReadValueTest : IReadValueTestBase, IDisposable
 {
-    private static AdsClient? adsClient;
-    private static PlcConnection? connection;
-    private static ReadWrite? readWrite;
-    private static SymbolHandler? symbolHandler;
+    private AdsClient? adsClient;
+    private PlcConnection? connection;
+    private bool disposed;
+    private ReadWrite? readWrite;
+    private SymbolHandler? symbolHandler;
 
-    [ClassInitialize]
-    public static async Task ConnectAsync(TestContext testContext)
+    [TestInitialize]
+    public async Task ConnectAsync()
     {
         var connectionsettings = new AdsPlcConnectionOptions() { AmsNetId = Settings.AmsNetId, Port = Settings.Port };
         var symbolhandlersettings = new AdsSymbolHandlerOptions() { StoreSymbolsToDisk = false };
@@ -34,12 +35,21 @@ public class ReadValueTest : IReadValueTestBase
         _ = await connection.GetConnectedClientAsync(TimeSpan.FromSeconds(1));
     }
 
-    [ClassCleanup]
-    public static void Disconnect()
+    [TestCleanup]
+    public void Disconnect()
+        => Dispose();
+
+    public void Dispose()
     {
-        connection!.Dispose();
-        adsClient!.Dispose();
-        symbolHandler!.Dispose();
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        connection?.Dispose();
+        adsClient?.Dispose();
+        symbolHandler?.Dispose();
     }
 
     protected override IReadWrite GetReadWrite()


### PR DESCRIPTION
Tests can be run in parallel, except for integration tests that need to write to the PLC (monitor and write tests)