### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/BuildTestDeploy.yml
+++ b/.github/workflows/BuildTestDeploy.yml
@@ -33,11 +33,11 @@ jobs:
         publicRelease: ${{ steps.nbgv.outputs.PublicRelease }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Nerdbank.GitVersioning
@@ -59,7 +59,7 @@ jobs:
         run: dotnet pack ${{ env.SOLUTION_NAME }} --configuration Release --verbosity normal --no-build --nologo --no-restore /p:Version=${{ steps.nbgv.outputs.SemVer2 }} --output ./bin/Pack/
       - name: Upload Artifact
         if: steps.pack.outcome == 'success'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.1
         with:
           name: nupkg
           path: |
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Download Artifact
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3.0.1
         with:
           name: nupkg
       - name: Push to GitHub Feed

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0)** on 2022-10-04T09:40:24Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v3.0.1](https://github.com/actions/download-artifact/releases/tag/v3.0.1)** on 2022-10-20T23:34:13Z
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v3.0.3](https://github.com/actions/setup-dotnet/releases/tag/v3.0.3)** on 2022-10-27T13:09:53Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v3.1.1](https://github.com/actions/upload-artifact/releases/tag/v3.1.1)** on 2022-10-21T19:20:02Z
