### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/BuildTestDeploy.yml
+++ b/.github/workflows/BuildTestDeploy.yml
@@ -34,7 +34,7 @@ jobs:
         publicRelease: ${{ steps.nbgv.outputs.PublicRelease }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
       - name: Setup .NET
@@ -60,7 +60,7 @@ jobs:
         run: dotnet pack ${{ env.SOLUTION_NAME }} --configuration Release --verbosity normal --no-build --nologo --no-restore /p:Version=${{ steps.nbgv.outputs.SemVer2 }} --output ./bin/Pack/
       - name: Upload Artifact
         if: steps.pack.outcome == 'success'
-        uses: actions/upload-artifact@v3.1.1
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: nupkg
           path: |
@@ -74,7 +74,7 @@ jobs:
     steps:
       - name: Download Artifact
         id: download
-        uses: actions/download-artifact@v3.0.1
+        uses: actions/download-artifact@v3.0.2
         with:
           name: nupkg
       - name: Setup github remotes

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v3.3.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.2
+        uses: saadmk11/github-actions-version-updater@v0.7.3
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.7.3](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.3)** on 2023-01-08T15:45:06Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v3.0.2](https://github.com/actions/download-artifact/releases/tag/v3.0.2)** on 2023-01-05T21:13:22Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v3.1.2](https://github.com/actions/upload-artifact/releases/tag/v3.1.2)** on 2023-01-06T14:29:05Z
