### PR TITLE
Typeconverter rewrite

### DIFF
--- a/src/PlcInterface.Abstraction/ITypeActivator.cs
+++ b/src/PlcInterface.Abstraction/ITypeActivator.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace PlcInterface;
+
+/// <summary>
+/// Encapsuls the logic to create a type by constructor with parameters, or default constructor with
+/// property setters.
+/// </summary>
+internal interface ITypeActivator
+{
+    /// <summary>
+    /// Try to create a instance.
+    /// </summary>
+    /// <param name="memberValueGetter">
+    /// A <see cref="Func{T, TResult}"/> for getting the value of the member with the given name.
+    /// </param>
+    /// <param name="memberCount">The number of members.</param>
+    /// <param name="instance">The created instance.</param>
+    /// <returns><see langword="true"/> if creation was succesfull, otherwise false.</returns>
+    /// <exception cref="SymbolException">is thrown when the data is invallid.</exception>
+    bool TryCreateInstance(Func<string, Type, object?> memberValueGetter, int memberCount, [MaybeNullWhen(false)] out object instance);
+}

--- a/src/PlcInterface.Abstraction/ObjectActivator.cs
+++ b/src/PlcInterface.Abstraction/ObjectActivator.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace PlcInterface;
+
+/// <summary>
+/// Encapsuls the logic to create a type by constructor with parameters, or default constructor with
+/// property setters.
+/// </summary>
+internal sealed class ObjectActivator : ITypeActivator
+{
+    private readonly Activator activator;
+    private readonly ParameterInfo[] parameters;
+    private readonly PropertySetterHelper[] properties;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObjectActivator"/> class.
+    /// </summary>
+    /// <param name="constructorInfo">The <see cref="ConstructorInfo"/> used to create the type.</param>
+    public ObjectActivator(ConstructorInfo constructorInfo)
+    {
+        if (constructorInfo.DeclaringType == null)
+        {
+            throw new ArgumentException("No declaring type defined.", nameof(constructorInfo));
+        }
+
+        parameters = constructorInfo.GetParameters();
+        activator = GetActivator(constructorInfo);
+        properties = constructorInfo.DeclaringType
+            .GetProperties()
+            .Where(x => x.CanWrite)
+            .Select(x => new PropertySetterHelper(x))
+            .ToArray();
+    }
+
+    private delegate object Activator(params object[] args);
+
+    /// <inheritdoc/>
+    public bool TryCreateInstance(Func<string, Type, object?> memberValueGetter, int memberCount, [MaybeNullWhen(false)] out object instance)
+    {
+        instance = default;
+        if (parameters.Length == memberCount)
+        {
+            var arguments = new object[parameters.Length];
+            var index = 0;
+            foreach (var parameter in parameters)
+            {
+                if (string.IsNullOrEmpty(parameter.Name))
+                {
+                    return false;
+                }
+
+                arguments[index++] = memberValueGetter.Invoke(parameter.Name, parameter.ParameterType)
+                    ?? throw new SymbolException($"Member: {parameter.Name} was null");
+            }
+
+            var argumentsArray = arguments.ToArray();
+            instance = activator.Invoke(argumentsArray);
+            return true;
+        }
+
+        if (properties.Length >= memberCount)
+        {
+            instance = activator.Invoke();
+            foreach (var property in properties)
+            {
+                var memberValue = memberValueGetter.Invoke(property.Name, property.PropertyType)
+                    ?? throw new SymbolException($"Member: {property.Name} was null");
+                property.Set(instance, memberValue);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private Activator GetActivator(ConstructorInfo constructorInfo)
+    {
+        // create a single param of type object[]
+        var param = Expression.Parameter(typeof(object[]), "args");
+        var argsExp = new Expression[parameters.Length];
+
+        // pick each arg from the params array and create a typed expression of them
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            Expression index = Expression.Constant(i);
+            var paramType = parameters[i].ParameterType;
+            Expression paramAccessorExp = Expression.ArrayIndex(param, index);
+            Expression paramCastExp = Expression.Convert(paramAccessorExp, paramType);
+            argsExp[i] = paramCastExp;
+        }
+
+        // make a NewExpression that calls the ctor with the args we just created
+        var newExp = Expression.New(constructorInfo, argsExp);
+
+        // create a lambda with the New Expression as body and our param object[] as arg
+        var lambda = Expression.Lambda<Activator>(newExp, param);
+
+        // compile it
+        var compiled = lambda.Compile();
+        return compiled;
+    }
+}

--- a/src/PlcInterface.Abstraction/PlcInterface.Abstraction.csproj
+++ b/src/PlcInterface.Abstraction/PlcInterface.Abstraction.csproj
@@ -4,6 +4,10 @@
     <Description>A PLC Abstraction</Description>
     <RootNamespace>PlcInterface</RootNamespace>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(CommonDirectory)\IndicesHelper.cs" LinkBase="Common" />
+  </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />

--- a/src/PlcInterface.Abstraction/PropertySetterHelper.cs
+++ b/src/PlcInterface.Abstraction/PropertySetterHelper.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace PlcInterface;
+
+/// <summary>
+/// Hellper for setting property values.
+/// </summary>
+internal sealed class PropertySetterHelper
+{
+    private readonly PropertyInfo propertyInfo;
+    private readonly PropertySetter setter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertySetterHelper"/> class.
+    /// </summary>
+    /// <param name="propertyInfo">The <see cref="PropertyInfo"/> to create a setter binding for.</param>
+    public PropertySetterHelper(PropertyInfo propertyInfo)
+    {
+        this.propertyInfo = propertyInfo;
+        setter = GetSetter();
+    }
+
+    private delegate void PropertySetter(object instance, object value);
+
+    /// <summary>
+    /// Gets the name of the property.
+    /// </summary>
+    public string Name => propertyInfo.Name;
+
+    /// <summary>
+    /// Gets the <see cref="Type"/> of the property.
+    /// </summary>
+    public Type PropertyType => propertyInfo.PropertyType;
+
+    /// <summary>
+    /// Set the given value to the given instance.
+    /// </summary>
+    /// <param name="instance">The instance containing the property.</param>
+    /// <param name="value">The value to set.</param>
+    public void Set(object instance, object value) => setter.Invoke(instance, value);
+
+    private PropertySetter GetSetter()
+    {
+        if (propertyInfo.DeclaringType == null)
+        {
+            throw new NotSupportedException($"{propertyInfo.Name} has no declaring type");
+        }
+
+        var instanceParam = Expression.Parameter(typeof(object));
+        var instanceParamCast = Expression.Convert(instanceParam, propertyInfo.DeclaringType);
+        var propertyParam = Expression.Parameter(typeof(object));
+        var propertyParamCast = Expression.Convert(propertyParam, propertyInfo.PropertyType);
+        var propertyGetterExpression = Expression.Property(instanceParamCast, propertyInfo.Name);
+        var assignExpression = Expression.Assign(propertyGetterExpression, propertyParamCast);
+        var lambda = Expression.Lambda<PropertySetter>(assignExpression, instanceParam, propertyParam);
+        var compiled = lambda.Compile();
+        return compiled;
+    }
+}

--- a/src/PlcInterface.Abstraction/StructActivator.cs
+++ b/src/PlcInterface.Abstraction/StructActivator.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace PlcInterface;
+
+/// <summary>
+/// Encapsuls the logic to create a type by constructor with parameters, or default constructor with
+/// property setters.
+/// </summary>
+internal sealed class StructActivator : ITypeActivator
+{
+    private readonly Activator activator;
+    private readonly PropertyInfo[] properties;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StructActivator"/> class.
+    /// </summary>
+    /// <param name="type">The type of the value type.</param>
+    public StructActivator(Type type)
+    {
+        activator = GetActivator(type);
+        properties = type
+            .GetProperties()
+            .Where(x => x.CanWrite)
+            .ToArray();
+    }
+
+    private delegate object Activator();
+
+    /// <summary>
+    /// Try to create a instance.
+    /// </summary>
+    /// <param name="memberValueGetter">
+    /// A <see cref="Func{T, TResult}"/> for getting the value of the member with the given name.
+    /// </param>
+    /// <param name="memberCount">The number of members.</param>
+    /// <param name="instance">The created instance.</param>
+    /// <returns><see langword="true"/> if creation was succesfull, otherwise false.</returns>
+    /// <exception cref="SymbolException">is thrown when the data is invallid.</exception>
+    public bool TryCreateInstance(Func<string, Type, object?> memberValueGetter, int memberCount, [MaybeNullWhen(false)] out object instance)
+    {
+        instance = default;
+        if (properties.Length >= memberCount)
+        {
+            instance = activator.Invoke();
+            foreach (var property in properties)
+            {
+                var memberValue = memberValueGetter.Invoke(property.Name, property.PropertyType)
+                    ?? throw new SymbolException($"Member: {property.Name} was null");
+                property.SetValue(instance, memberValue);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static Activator GetActivator(Type type)
+    {
+        // make a NewExpression that calls the ctor with the args we just created
+        var newExp = Expression.New(type);
+        var cast = Expression.Convert(newExp, typeof(object));
+
+        // create a lambda with the New Expression as body and our param object[] as arg
+        var lambda = Expression.Lambda<Activator>(cast);
+
+        // compile it
+        var compiled = lambda.Compile();
+        return compiled;
+    }
+}

--- a/src/PlcInterface.Abstraction/TypeConverter.cs
+++ b/src/PlcInterface.Abstraction/TypeConverter.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Dynamic;
 using System.Globalization;
 
 namespace PlcInterface;
@@ -27,11 +29,143 @@ public abstract class TypeConverter : ITypeConverter
             return value;
         }
 
+        if (value is DateTime dateTime && targetType == typeof(DateTimeOffset))
+        {
+            return new DateTimeOffset(dateTime);
+        }
+
         if (targetType.IsEnum)
         {
             return Enum.ToObject(targetType, value);
         }
 
-        return System.Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
+        if (targetType.IsArray && value is Array expandArray)
+        {
+            return ConvertArray(expandArray, targetType);
+        }
+
+        if (value is ExpandoObject expandoObject)
+        {
+            return ConvertExpando(expandoObject, targetType);
+        }
+
+        if (value is DynamicObject dynamicObject)
+        {
+            return ConvertDynamic(dynamicObject, targetType);
+        }
+
+        try
+        {
+            return System.Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
+        }
+        catch (InvalidCastException ex)
+        {
+            throw new SymbolException(ex.Message);
+        }
+    }
+
+    private object ConvertArray(Array expandArray, Type targetType)
+    {
+        var elementType = targetType.GetElementType() ?? throw new NotSupportedException($"Unable to retrieve element type");
+        var dimensionLengts = new int[expandArray.Rank];
+        for (var i = 0; i < expandArray.Rank; i++)
+        {
+            dimensionLengts[i] = expandArray.GetLength(i);
+        }
+
+        var destination = Array.CreateInstance(elementType, dimensionLengts);
+        foreach (var indices in IndicesHelper.GetIndices(destination))
+        {
+            var dynamicValue = expandArray.GetValue(indices)
+                ?? throw new SymbolException($"No value found at index: {indices}");
+            destination.SetValue(Convert(dynamicValue, elementType), indices);
+        }
+
+        return destination;
+    }
+
+    private object ConvertDynamic(DynamicObject dynamicObject, Type targetType)
+    {
+        if (targetType.IsArray)
+        {
+            throw new NotSupportedException($"Can't convert from {typeof(DynamicObject)} to {targetType}");
+        }
+
+        var destination = Activator.CreateInstance(targetType)
+            ?? throw new NotSupportedException($"Unable to create a instance for type: {targetType.Name}");
+
+        foreach (var memberName in dynamicObject.GetDynamicMemberNames())
+        {
+            var property = targetType.GetProperty(memberName)
+                ?? throw new InvalidOperationException($"{memberName} not found as a property");
+
+            if (!property.CanWrite)
+            {
+                throw new InvalidOperationException($"{property.Name} is not writable");
+            }
+
+            if (!dynamicObject.TryGetMember(new MemberBinder(memberName, true), out var memberValue))
+            {
+                throw new InvalidOperationException($"{memberName} is not found in the PLC type");
+            }
+
+            if (memberValue == null)
+            {
+                throw new SymbolException($"Member: {property.Name} was null");
+            }
+
+            var convertedValue = Convert(memberValue, property.PropertyType);
+            property.SetValue(destination, convertedValue);
+        }
+
+        return destination;
+    }
+
+    private object ConvertExpando(ExpandoObject expandoObject, Type targetType)
+    {
+        var destination = Activator.CreateInstance(targetType)
+            ?? throw new NotSupportedException($"Unable to create a instance for type: {targetType.Name}");
+
+        foreach (var (memberName, memberValue) in expandoObject)
+        {
+            var property = targetType.GetProperty(memberName)
+                ?? throw new InvalidOperationException($"{memberName} not found as a property");
+
+            if (!property.CanWrite)
+            {
+                throw new InvalidOperationException($"{property.Name} is not writable");
+            }
+
+            if (memberValue == null)
+            {
+                throw new SymbolException($"Member: {property.Name} was null");
+            }
+
+            var convertedValue = Convert(memberValue, property.PropertyType);
+            property.SetValue(destination, convertedValue);
+        }
+
+        return destination;
+    }
+
+    /// <summary>
+    /// A simple implementation of <see cref="GetMemberBinder"/>.
+    /// </summary>
+    protected sealed class MemberBinder : GetMemberBinder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemberBinder"/> class.
+        /// </summary>
+        /// <param name="name">The name of the member to get.</param>
+        /// <param name="ignoreCase">true if the name should be matched ignoring case; false otherwise.</param>
+        public MemberBinder(string name, bool ignoreCase)
+            : base(name, ignoreCase)
+        {
+        }
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        public override DynamicMetaObject FallbackGetMember(DynamicMetaObject target, DynamicMetaObject? errorSuggestion)
+            => throw new NotSupportedException();
     }
 }

--- a/src/PlcInterface.Ads/AdsTypeConverter.cs
+++ b/src/PlcInterface.Ads/AdsTypeConverter.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.Globalization;
-using TwinCAT.Ads.TypeSystem;
 using TwinCAT.TypeSystem;
 
 namespace PlcInterface.Ads;
@@ -37,182 +35,51 @@ public sealed class AdsTypeConverter : TypeConverter, IAdsTypeConverter
     /// <inheritdoc/>
     public override object Convert(object value, Type targetType)
     {
-        if (value is DynamicObject dynamicObject)
+        if (value is TwinCAT.PlcOpen.DateBase dateBase)
         {
-            return ConvertFrom(dynamicObject, targetType);
+            if (targetType == typeof(DateTimeOffset))
+            {
+                return new DateTimeOffset(dateBase.Value);
+            }
+
+            return dateBase.Value;
         }
 
-        if (value is DateTime dateTime && targetType == typeof(DateTimeOffset))
+        if (value is TwinCAT.PlcOpen.TimeBase timeBase)
         {
-            return new DateTimeOffset(dateTime);
+            return timeBase.Time;
         }
 
-        if (targetType.IsArray && value is Array dynamicObjects)
+        if (value is TwinCAT.PlcOpen.LTimeBase lTimeBase)
         {
-            return ConvertArray(dynamicObjects, targetType);
+            return lTimeBase.Time;
+        }
+
+        if (value is IDynamicValue valueObject && valueObject.DataType is IArrayType arrayType)
+        {
+            return ConvertDynamicValueArray(valueObject, arrayType, targetType);
         }
 
         return base.Convert(value, targetType);
     }
 
-    private Array ConvertArray(Array dynamicObjects, Type type)
+    private object ConvertDynamicValueArray(IDynamicValue valueObject, IArrayType arrayType, Type targetType)
     {
-        var elementType = type.GetElementType() ?? throw new NotSupportedException($"Unable to retrieve element type");
-        var dimensionLengts = new int[dynamicObjects.Rank];
-        for (var i = 0; i < dynamicObjects.Rank; i++)
-        {
-            dimensionLengts[i] = dynamicObjects.GetLength(i);
-        }
-
-        var destination = Array.CreateInstance(elementType, dimensionLengts);
-        foreach (var indices in IndicesHelper.GetIndices(destination))
-        {
-            object? result;
-            try
-            {
-                result = dynamicObjects.GetValue(indices);
-            }
-            catch (Exception)
-            {
-                throw new SymbolException($"No value found at index {indices}");
-            }
-
-            if (result == null)
-            {
-                var canBeNull = !elementType.IsValueType || (Nullable.GetUnderlyingType(elementType) != null);
-                if (!canBeNull)
-                {
-                    throw new SymbolException($"Can't assign null to array");
-                }
-
-                destination.SetValue(result, indices);
-            }
-            else if (result is DynamicObject resultDynamicObject)
-            {
-                var value = ConvertFrom(resultDynamicObject, elementType);
-                destination.SetValue(value, indices);
-            }
-            else if (result.GetType() == elementType)
-            {
-                destination.SetValue(result, indices);
-            }
-            else
-            {
-                throw new SymbolException($"Unable to convert type {result}");
-            }
-        }
-
-        return destination;
-    }
-
-    private Array ConvertArray(DynamicObject dynamicObject, Type type)
-    {
-        if (dynamicObject is not IDynamicValue valueObject)
-        {
-            throw new NotSupportedException($"dynamic object is not a {typeof(IDynamicValue)}");
-        }
-
-        if (valueObject.DataType is not IArrayType dataType)
-        {
-            throw new NotSupportedException($"Data Type is not a {typeof(ArrayType)}");
-        }
-
-        var ellementType = type.GetElementType()
+        var elementType = targetType.GetElementType()
             ?? throw new NotSupportedException($"Unable to retrieve element type");
-        var dimensionLengts = dataType.Dimensions.GetDimensionLengths();
-        var destination = Array.CreateInstance(ellementType, dimensionLengts);
+        var dimensionLengts = arrayType.Dimensions.GetDimensionLengths();
+        var destination = Array.CreateInstance(elementType, dimensionLengts);
 
         foreach (var indices in IndicesHelper.GetIndices(destination))
         {
-            if (!valueObject.TryGetIndexValue(indices, out var result))
+            if (!valueObject.TryGetIndexValue(indices, out var memberValue))
             {
                 throw new SymbolException($"No value found at index {indices}");
             }
 
-            if (result is DynamicObject resultDynamicObject)
-            {
-                var value = ConvertFrom(resultDynamicObject, ellementType);
-                destination.SetValue(value, indices);
-            }
-            else if (result.GetType() == ellementType)
-            {
-                destination.SetValue(result, indices);
-            }
-            else
-            {
-                throw new SymbolException($"Unable to convert type {result}");
-            }
+            destination.SetValue(Convert(memberValue, elementType), indices);
         }
 
         return destination;
-    }
-
-    private object ConvertFrom(DynamicObject dynamicObject, Type type)
-    {
-        if (type.IsArray)
-        {
-            return ConvertArray(dynamicObject, type);
-        }
-
-        var destination = Activator.CreateInstance(type) ?? throw new NotSupportedException($"Unable to create a instance for type: {type.Name}");
-        foreach (var memberName in dynamicObject.GetDynamicMemberNames())
-        {
-            var property = type.GetProperty(memberName)
-                ?? throw new InvalidOperationException($"{memberName} not found as a property");
-
-            if (!property.CanWrite)
-            {
-                throw new InvalidOperationException($"{property.Name} is not writable");
-            }
-
-            if (!dynamicObject.TryGetMember(new MemberBinder(property.Name, true), out var result))
-            {
-                throw new InvalidOperationException($"{property.Name} is not found in the PLC type");
-            }
-
-            if (result is DynamicObject resultDynamicObject)
-            {
-                var value = ConvertFrom(resultDynamicObject, property.PropertyType);
-                property.SetValue(destination, value);
-            }
-            else if (result is TwinCAT.PlcOpen.DateBase dateBase)
-            {
-                if (property.PropertyType == typeof(DateTimeOffset))
-                {
-                    property.SetValue(destination, new DateTimeOffset(dateBase.Value));
-                }
-                else
-                {
-                    property.SetValue(destination, dateBase.Value);
-                }
-            }
-            else if (result is TwinCAT.PlcOpen.TimeBase timeBase)
-            {
-                property.SetValue(destination, timeBase.Time);
-            }
-            else if (result is TwinCAT.PlcOpen.LTimeBase lTimeBase)
-            {
-                property.SetValue(destination, lTimeBase.Time);
-            }
-            else
-            {
-                property.SetValue(destination, result);
-                continue;
-            }
-        }
-
-        return destination;
-    }
-
-    private sealed class MemberBinder : GetMemberBinder
-    {
-        public MemberBinder(string name, bool ignoreCase)
-            : base(name, ignoreCase)
-        {
-        }
-
-        [ExcludeFromCodeCoverage]
-        public override DynamicMetaObject FallbackGetMember(DynamicMetaObject target, DynamicMetaObject? errorSuggestion)
-            => throw new NotSupportedException();
     }
 }

--- a/src/PlcInterface.OpcUa/IOpcTypeConverter.cs
+++ b/src/PlcInterface.OpcUa/IOpcTypeConverter.cs
@@ -18,9 +18,8 @@ public interface IOpcTypeConverter : ITypeConverter
     /// <summary>
     /// Create a dynamic type.
     /// </summary>
-    /// <param name="symbolInfo"><see cref="ISymbolInfo"/> of the type to convert.</param>
+    /// <param name="symbolName">The name of the root symbol.</param>
     /// <param name="valueEnumerator">a <see cref="IEnumerator{T}"/> to enumerate the values.</param>
-    /// <param name="symbolHandler">A <see cref="ISymbolHandler"/> to get type info from.</param>
-    /// <returns>A dynamic object representing the <paramref name="symbolInfo"/>.</returns>
-    dynamic CreateDynamic(ISymbolInfo symbolInfo, IEnumerator<DataValue> valueEnumerator, ISymbolHandler symbolHandler);
+    /// <returns>A dynamic object representing the <paramref name="symbolName"/>.</returns>
+    dynamic CreateDynamic(string symbolName, IEnumerator<DataValue> valueEnumerator);
 }

--- a/src/PlcInterface.OpcUa/ReadWrite.cs
+++ b/src/PlcInterface.OpcUa/ReadWrite.cs
@@ -63,8 +63,7 @@ public class ReadWrite : IOpcReadWrite, IDisposable
         var result = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
         foreach (var ioName in ioNames)
         {
-            var symbolInfo = symbolHandler.GetSymbolinfo(ioName).ConvertAndValidate();
-            var value = typeConverter.CreateDynamic(symbolInfo, valueEnumerator, symbolHandler);
+            var value = typeConverter.CreateDynamic(ioName, valueEnumerator);
             result.Add(ioName, typeConverter.Convert(value));
         }
 
@@ -136,8 +135,7 @@ public class ReadWrite : IOpcReadWrite, IDisposable
                     var result = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
                     foreach (var ioName in ioNames)
                     {
-                        var symbolInfo = symbolHandler.GetSymbolinfo(ioName).ConvertAndValidate();
-                        var value = typeConverter.CreateDynamic(symbolInfo, valueEnumerator, symbolHandler);
+                        var value = typeConverter.CreateDynamic(ioName, valueEnumerator);
                         result.Add(ioName, typeConverter.Convert(value));
                     }
 

--- a/test/PlcInterface.Abstraction/PlcInterface.Abstraction.Tests.csproj
+++ b/test/PlcInterface.Abstraction/PlcInterface.Abstraction.Tests.csproj
@@ -18,5 +18,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\PlcInterface.Abstraction\PlcInterface.Abstraction.csproj" />
+    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
 </Project>

--- a/test/PlcInterface.Abstraction/TypeConverterTests.cs
+++ b/test/PlcInterface.Abstraction/TypeConverterTests.cs
@@ -113,7 +113,6 @@ public class TypeConverterTests
         source.Add(nameof(TestType.IntValue), expected.IntValue);
         source.Add(nameof(TestType.IntArray), expected.IntArray);
         source.Add(nameof(TestType.SubType), expected.SubType.GetDynamicObjectMock());
-        var result = new object();
 
         // Act
         var actual = typeConverter.Convert<TestType>(source);
@@ -222,7 +221,7 @@ public class TypeConverterTests
     }
 
     [TestMethod]
-    public void ConvertThrowsInvalidOperationExceptionWhenDynamicObjectHasNoValue()
+    public void ConvertThrowsNotSupportedExceptionWhenDynamicObjectHasNoValue()
     {
         // Arrange
         var typeConverter = Converter;
@@ -233,11 +232,11 @@ public class TypeConverterTests
         _ = sourceMock.Setup(x => x.TryGetMember(It.IsAny<GetMemberBinder>(), out value)).Returns(false);
 
         // Act
-        _ = Assert.ThrowsException<InvalidOperationException>(() => typeConverter.Convert<TestType>(sourceMock.Object));
+        _ = Assert.ThrowsException<NotSupportedException>(() => typeConverter.Convert<TestType>(sourceMock.Object));
     }
 
     [TestMethod]
-    public void ConvertThrowsInvalidOperationExceptionWhenPropertyIsNotFound()
+    public void ConvertThrowsNotSupportedExceptionWhenPropertyIsNotFound()
     {
         // Arrange
         var typeConverter = Converter;
@@ -246,11 +245,11 @@ public class TypeConverterTests
         _ = sourceMock.Setup(x => x.GetDynamicMemberNames()).Returns(new[] { "IntValue2" });
 
         // Act
-        _ = Assert.ThrowsException<InvalidOperationException>(() => typeConverter.Convert<TestType>(sourceMock.Object));
+        _ = Assert.ThrowsException<NotSupportedException>(() => typeConverter.Convert<TestType>(sourceMock.Object));
     }
 
     [TestMethod]
-    public void ConvertThrowsInvalidOperationExceptionWhenPropertyIsReadOnly()
+    public void ConvertThrowsNotSupportedExceptionWhenPropertyIsReadOnly()
     {
         // Arrange
         var typeConverter = Converter;
@@ -263,8 +262,8 @@ public class TypeConverterTests
             .Returns(new[] { nameof(NoSetterTestType.IntValue) });
 
         // Act Assert
-        _ = Assert.ThrowsException<InvalidOperationException>(() => typeConverter.Convert<NoSetterTestType>(sourceMock.Object));
-        _ = Assert.ThrowsException<InvalidOperationException>(() => typeConverter.Convert<NoSetterTestType>(expandoSource));
+        _ = Assert.ThrowsException<NotSupportedException>(() => typeConverter.Convert<NoSetterTestType>(sourceMock.Object));
+        _ = Assert.ThrowsException<NotSupportedException>(() => typeConverter.Convert<NoSetterTestType>(expandoSource));
     }
 
     [TestMethod]
@@ -286,6 +285,8 @@ public class TypeConverterTests
         var typeConverter = Converter;
         var expandoSource = new ExpandoObject() as IDictionary<string, object>;
         expandoSource.Add(nameof(TestType.IntValue), null!);
+        expandoSource.Add(nameof(TestType.IntArray), null!);
+        expandoSource.Add(nameof(TestType.SubType), null!);
         var dynamicObjectsourceMock = new Mock<DynamicObject>();
         var result = new object();
         _ = dynamicObjectsourceMock.Setup(x => x.GetDynamicMemberNames())

--- a/test/PlcInterface.Abstraction/TypeConverterTests.cs
+++ b/test/PlcInterface.Abstraction/TypeConverterTests.cs
@@ -1,5 +1,9 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using TestUtilities;
 
 namespace PlcInterface.Abstraction.Tests;
 
@@ -16,19 +20,123 @@ public class TypeConverterTests
         Value5,
     }
 
+    private static TypeConverter Converter => new Mock<TypeConverter> { CallBase = true, }.Object;
+
     [TestMethod]
-    public void ConvertConvertsObjectToRequestedType()
+    public void ConvertConvertsDateTimeToDateTimeOffset()
     {
         // Arrange
-        var typeConverterMock = new Mock<TypeConverter>
+        var typeConverter = Converter;
+        var dateTime = DateTime.Now;
+
+        // Act
+        var actual = typeConverter.Convert<DateTimeOffset>(dateTime);
+
+        // Assert
+        Assert.IsInstanceOfType(actual, typeof(DateTimeOffset));
+        Assert.AreEqual(new DateTimeOffset(dateTime), actual);
+    }
+
+    [TestMethod]
+    public void ConvertConvertsDynamicArrayToArray()
+    {
+        // Arrange
+        var typeConverter = Converter;
+        var expected = new[]
         {
-            CallBase = true,
+            new NestedType() { IntValue = 2 },
+            new NestedType() { IntValue = 3 },
+            new NestedType() { IntValue = 4 },
+            new NestedType() { IntValue = 5 },
+            new NestedType() { IntValue = 6 },
         };
+        var source = new DynamicObject[]
+        {
+            expected[0].GetDynamicObjectMock(),
+            expected[1].GetDynamicObjectMock(),
+            expected[2].GetDynamicObjectMock(),
+            expected[3].GetDynamicObjectMock(),
+            expected[4].GetDynamicObjectMock(),
+        };
+
+        // Act
+        var actual = typeConverter.Convert<NestedType[]>(source);
+
+        // Assert
+        Assert.AreEqual(expected[0].IntValue, actual[0].IntValue);
+        Assert.AreEqual(expected[1].IntValue, actual[1].IntValue);
+        Assert.AreEqual(expected[2].IntValue, actual[2].IntValue);
+        Assert.AreEqual(expected[3].IntValue, actual[3].IntValue);
+        Assert.AreEqual(expected[4].IntValue, actual[4].IntValue);
+    }
+
+    [TestMethod]
+    public void ConvertConvertsDynamicObjectToType()
+    {
+        // Arrange
+        var typeConverter = Converter;
+        var expected = TestType.Instance;
+        var sourceMock = new Mock<DynamicObject>();
+        var result = new object();
+        _ = sourceMock.Setup(x => x.GetDynamicMemberNames()).Returns(new[] { nameof(TestType.IntValue), nameof(TestType.IntArray), nameof(TestType.SubType) });
+        _ = sourceMock.Setup(x => x.TryGetMember(It.IsAny<GetMemberBinder>(), out result)).Returns(new MockDelegates.OutFunction<GetMemberBinder, object, bool>((GetMemberBinder binder, out object value) =>
+        {
+            value = binder.Name switch
+            {
+                nameof(TestType.IntValue) => expected.IntValue,
+                nameof(TestType.IntArray) => expected.IntArray,
+                _ => expected.SubType.GetDynamicObjectMock(),
+            };
+
+            return value != null;
+        }));
+
+        // Act
+        var actual = typeConverter.Convert<TestType>(sourceMock.Object);
+
+        // Assert
+        Assert.IsInstanceOfType(actual, typeof(TestType));
+        Assert.AreEqual(expected.IntValue, actual.IntValue);
+        CollectionAssert.AreEqual(expected.IntArray, actual.IntArray);
+
+        Assert.IsNotNull(actual.SubType);
+        Assert.AreEqual(expected.SubType.IntValue, actual.SubType.IntValue);
+    }
+
+    [TestMethod]
+    public void ConvertConvertsExpandoToRequestedType()
+    {
+        // Arrange
+        var typeConverter = Converter;
+        var expected = TestType.Instance;
+        var source = new ExpandoObject() as IDictionary<string, object>;
+        source.Add(nameof(TestType.IntValue), expected.IntValue);
+        source.Add(nameof(TestType.IntArray), expected.IntArray);
+        source.Add(nameof(TestType.SubType), expected.SubType.GetDynamicObjectMock());
+        var result = new object();
+
+        // Act
+        var actual = typeConverter.Convert<TestType>(source);
+
+        // Assert
+        Assert.IsInstanceOfType(actual, typeof(TestType));
+        Assert.AreEqual(expected.IntValue, actual.IntValue);
+        CollectionAssert.AreEqual(expected.IntArray, actual.IntArray);
+
+        Assert.IsNotNull(actual.SubType);
+        Assert.AreEqual(expected.SubType.IntValue, actual.SubType.IntValue);
+    }
+
+    [TestMethod]
+    public void ConvertConvertsStringToRequestedInt()
+    {
+        // Arrange
+        var typeConverter = Converter;
         var stringObject = "100";
 
         // Act
-        var actual = typeConverterMock.Object.Convert<int>(stringObject);
-        var actual2 = typeConverterMock.Object.Convert(stringObject, typeof(int));
+        var actual = typeConverter.Convert<int>(stringObject);
+        var actual2 = typeConverter.Convert(stringObject, typeof(int));
 
         // Assert
         Assert.IsInstanceOfType(actual, typeof(int));
@@ -41,16 +149,12 @@ public class TypeConverterTests
     public void ConvertConvertsToEnum()
     {
         // Arrange
-        var typeConverterMock = new Mock<TypeConverter>
-        {
-            CallBase = true,
-        };
-
+        var typeConverter = Converter;
         var value = 4;
 
         // Act
-        var actual = typeConverterMock.Object.Convert<TestEnum>(value);
-        var actual2 = typeConverterMock.Object.Convert(value, typeof(TestEnum));
+        var actual = typeConverter.Convert<TestEnum>(value);
+        var actual2 = typeConverter.Convert(value, typeof(TestEnum));
 
         // Assert
         Assert.AreEqual(TestEnum.Value4, actual);
@@ -63,19 +167,191 @@ public class TypeConverterTests
     public void ConvertReturnsSourceObjectIfAlreadyTheRightType()
     {
         // Arrange
-        var typeConverterMock = new Mock<TypeConverter>
-        {
-            CallBase = true,
-        };
+        var typeConverter = Converter;
         object expected = new GenericParameterHelper();
 
         // Act
-        var actual = typeConverterMock.Object.Convert<GenericParameterHelper>(expected);
-        var actual2 = typeConverterMock.Object.Convert(expected, typeof(GenericParameterHelper));
+        var actual = typeConverter.Convert<GenericParameterHelper>(expected);
+        var actual2 = typeConverter.Convert(expected, typeof(GenericParameterHelper));
 
         // Assert
         Assert.IsInstanceOfType(actual, typeof(GenericParameterHelper));
         Assert.AreEqual(expected, actual);
         Assert.AreEqual(expected, actual2);
+    }
+
+    [TestMethod]
+    public void ConvertThrowsInvalidOperationExceptionWhenDynamicObjectHasNoValue()
+    {
+        // Arrange
+        var typeConverter = Converter;
+        var sourceMock = new Mock<DynamicObject>();
+        var result = new object();
+        _ = sourceMock.Setup(x => x.GetDynamicMemberNames()).Returns(new[] { nameof(TestType.IntValue) });
+        var value = new object();
+        _ = sourceMock.Setup(x => x.TryGetMember(It.IsAny<GetMemberBinder>(), out value)).Returns(false);
+
+        // Act
+        _ = Assert.ThrowsException<InvalidOperationException>(() => typeConverter.Convert<TestType>(sourceMock.Object));
+    }
+
+    [TestMethod]
+    public void ConvertThrowsInvalidOperationExceptionWhenPropertyIsNotFound()
+    {
+        // Arrange
+        var typeConverter = Converter;
+        var sourceMock = new Mock<DynamicObject>();
+        var result = new object();
+        _ = sourceMock.Setup(x => x.GetDynamicMemberNames()).Returns(new[] { "IntValue2" });
+
+        // Act
+        _ = Assert.ThrowsException<InvalidOperationException>(() => typeConverter.Convert<TestType>(sourceMock.Object));
+    }
+
+    [TestMethod]
+    public void ConvertThrowsInvalidOperationExceptionWhenPropertyIsReadOnly()
+    {
+        // Arrange
+        var typeConverter = Converter;
+        var expected = TestType.Instance;
+        var sourceMock = new Mock<DynamicObject>();
+        var expandoSource = new ExpandoObject() as IDictionary<string, object>;
+        expandoSource.Add(nameof(NoSetterTestType.IntValue), 10);
+        var result = new object();
+        _ = sourceMock.Setup(x => x.GetDynamicMemberNames())
+            .Returns(new[] { nameof(NoSetterTestType.IntValue) });
+
+        // Act Assert
+        _ = Assert.ThrowsException<InvalidOperationException>(() => typeConverter.Convert<NoSetterTestType>(sourceMock.Object));
+        _ = Assert.ThrowsException<InvalidOperationException>(() => typeConverter.Convert<NoSetterTestType>(expandoSource));
+    }
+
+    [TestMethod]
+    public void ConvertThrowsNotSupportedExceptionWhenTargetIsArrayButValueIsNotIDynamicValue()
+    {
+        // Arrange
+        var typeConverter = Converter;
+        var expected = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        var sourceMock = new Mock<DynamicObject>();
+
+        // Act Assert
+        _ = Assert.ThrowsException<NotSupportedException>(() => typeConverter.Convert<int[]>(sourceMock.Object));
+    }
+
+    [TestMethod]
+    public void ConvertThrowsSymbolExceptionWhenMemberIsNull()
+    {
+        // Arrange
+        var typeConverter = Converter;
+        var expandoSource = new ExpandoObject() as IDictionary<string, object>;
+        expandoSource.Add(nameof(TestType.IntValue), null!);
+        var dynamicObjectsourceMock = new Mock<DynamicObject>();
+        var result = new object();
+        _ = dynamicObjectsourceMock.Setup(x => x.GetDynamicMemberNames())
+            .Returns(new[]
+            {
+                nameof(TestType.IntValue),
+                nameof(TestType.IntArray),
+                nameof(TestType.SubType),
+            });
+        _ = dynamicObjectsourceMock.Setup(x => x.TryGetMember(It.IsAny<GetMemberBinder>(), out result))
+            .Returns(new MockDelegates.OutFunction<GetMemberBinder, object, bool>((GetMemberBinder binder, out object value) =>
+            {
+                value = binder.Name switch
+                {
+                    _ => null!,
+                };
+
+                return true;
+            }));
+        var dynamicObjectsource = dynamicObjectsourceMock.Object;
+
+        // Act Assert
+        _ = Assert.ThrowsException<SymbolException>(() => typeConverter.Convert<TestType>(dynamicObjectsource));
+        _ = Assert.ThrowsException<SymbolException>(() => typeConverter.Convert<TestType>(expandoSource));
+    }
+
+    [TestMethod]
+    public void ConvertThrowsSymbolExceptionWhenTypeCantBeConverted()
+    {
+        // Arrange
+        var typeConverter = Converter;
+        var source = TestType.Instance;
+
+        // Act Assert
+        _ = Assert.ThrowsException<SymbolException>(() => typeConverter.Convert<int>(source));
+    }
+
+    private sealed class NestedType
+    {
+        public int IntValue
+        {
+            get;
+            set;
+        }
+
+        internal DynamicObject GetDynamicObjectMock()
+        {
+            var sourceMock = new Mock<DynamicObject>();
+            var result = new object();
+            _ = sourceMock.Setup(x => x.GetDynamicMemberNames()).Returns(new[] { nameof(IntValue) });
+            _ = sourceMock.Setup(x => x.TryGetMember(It.IsAny<GetMemberBinder>(), out result))
+                .Returns(new MockDelegates.OutFunction<GetMemberBinder, object, bool>((GetMemberBinder binder, out object value) =>
+                {
+                    value = binder.Name switch
+                    {
+                        _ => IntValue,
+                    };
+
+                    return value != null;
+                }));
+
+            return sourceMock.Object;
+        }
+    }
+
+    private sealed class NoSetterTestType
+    {
+        public int IntValue
+        {
+            get;
+        }
+    }
+
+    private sealed class TestType
+    {
+        public static readonly TestType Instance = new()
+        {
+            IntValue = 5,
+            IntArray = new[] { 6, 7, 8, 9 },
+            SubType = new NestedType()
+            {
+                IntValue = 12,
+            },
+        };
+
+        public TestType()
+        {
+            IntArray = Array.Empty<int>();
+            SubType = new NestedType();
+        }
+
+        public int[] IntArray
+        {
+            get;
+            set;
+        }
+
+        public int IntValue
+        {
+            get;
+            set;
+        }
+
+        public NestedType SubType
+        {
+            get;
+            set;
+        }
     }
 }

--- a/test/PlcInterface.Abstraction/TypeConverterTests.cs
+++ b/test/PlcInterface.Abstraction/TypeConverterTests.cs
@@ -221,22 +221,7 @@ public class TypeConverterTests
     }
 
     [TestMethod]
-    public void ConvertThrowsNotSupportedExceptionWhenDynamicObjectHasNoValue()
-    {
-        // Arrange
-        var typeConverter = Converter;
-        var sourceMock = new Mock<DynamicObject>();
-        var result = new object();
-        _ = sourceMock.Setup(x => x.GetDynamicMemberNames()).Returns(new[] { nameof(TestType.IntValue) });
-        var value = new object();
-        _ = sourceMock.Setup(x => x.TryGetMember(It.IsAny<GetMemberBinder>(), out value)).Returns(false);
-
-        // Act
-        _ = Assert.ThrowsException<NotSupportedException>(() => typeConverter.Convert<TestType>(sourceMock.Object));
-    }
-
-    [TestMethod]
-    public void ConvertThrowsNotSupportedExceptionWhenPropertyIsNotFound()
+    public void ConvertSymbolExceptionWhenPropertyIsNotFound()
     {
         // Arrange
         var typeConverter = Converter;
@@ -245,7 +230,7 @@ public class TypeConverterTests
         _ = sourceMock.Setup(x => x.GetDynamicMemberNames()).Returns(new[] { "IntValue2" });
 
         // Act
-        _ = Assert.ThrowsException<NotSupportedException>(() => typeConverter.Convert<TestType>(sourceMock.Object));
+        _ = Assert.ThrowsException<SymbolException>(() => typeConverter.Convert<TestType>(sourceMock.Object));
     }
 
     [TestMethod]
@@ -276,6 +261,21 @@ public class TypeConverterTests
 
         // Act Assert
         _ = Assert.ThrowsException<NotSupportedException>(() => typeConverter.Convert<int[]>(sourceMock.Object));
+    }
+
+    [TestMethod]
+    public void ConvertThrowsSymbolExceptionWhenDynamicObjectHasNoValue()
+    {
+        // Arrange
+        var typeConverter = Converter;
+        var sourceMock = new Mock<DynamicObject>();
+        var result = new object();
+        _ = sourceMock.Setup(x => x.GetDynamicMemberNames()).Returns(new[] { nameof(TestType.IntValue) });
+        var value = new object();
+        _ = sourceMock.Setup(x => x.TryGetMember(It.IsAny<GetMemberBinder>(), out value)).Returns(false);
+
+        // Act
+        _ = Assert.ThrowsException<SymbolException>(() => typeConverter.Convert<TestType>(sourceMock.Object));
     }
 
     [TestMethod]

--- a/test/PlcInterface.Opc.IntegrationTests/MonitorTest.cs
+++ b/test/PlcInterface.Opc.IntegrationTests/MonitorTest.cs
@@ -29,10 +29,10 @@ public class MonitorTest : IMonitorTestBase
         var connectionsettings = new OpcPlcConnectionOptions();
         new DefaultOpcPlcConnectionConfigureOptions().Configure(connectionsettings);
         connectionsettings.Address = Settings.PLCUri;
-        var typeConverter = new OpcTypeConverter();
 
         connection = new PlcConnection(MockHelpers.GetOptionsMoq(connectionsettings), MockHelpers.GetLoggerMock<PlcConnection>());
         symbolHandler = new SymbolHandler(connection, MockHelpers.GetLoggerMock<SymbolHandler>());
+        var typeConverter = new OpcTypeConverter(symbolHandler);
         readWrite = new ReadWrite(connection, symbolHandler, typeConverter, MockHelpers.GetLoggerMock<ReadWrite>());
         monitor = new Monitor(connection, symbolHandler, typeConverter, MockHelpers.GetLoggerMock<Monitor>());
     }

--- a/test/PlcInterface.Opc.IntegrationTests/ReadValueTest.cs
+++ b/test/PlcInterface.Opc.IntegrationTests/ReadValueTest.cs
@@ -21,7 +21,6 @@ public sealed class ReadValueTest : IReadValueTestBase, IDisposable
         var connectionsettings = new OpcPlcConnectionOptions();
         new DefaultOpcPlcConnectionConfigureOptions().Configure(connectionsettings);
         connectionsettings.Address = Settings.PLCUri;
-        var typeConverter = new OpcTypeConverter();
 
         connection?.Dispose();
         symbolHandler?.Dispose();
@@ -29,6 +28,7 @@ public sealed class ReadValueTest : IReadValueTestBase, IDisposable
 
         connection = new PlcConnection(MockHelpers.GetOptionsMoq(connectionsettings), MockHelpers.GetLoggerMock<PlcConnection>());
         symbolHandler = new SymbolHandler(connection, MockHelpers.GetLoggerMock<SymbolHandler>());
+        var typeConverter = new OpcTypeConverter(symbolHandler);
         readWrite = new ReadWrite(connection, symbolHandler, typeConverter, MockHelpers.GetLoggerMock<ReadWrite>());
 
         await connection.ConnectAsync();

--- a/test/PlcInterface.Opc.IntegrationTests/WriteValueTest.cs
+++ b/test/PlcInterface.Opc.IntegrationTests/WriteValueTest.cs
@@ -20,10 +20,10 @@ public class WriteValueTest : IWriteValueTestBase
         var connectionsettings = new OpcPlcConnectionOptions();
         new DefaultOpcPlcConnectionConfigureOptions().Configure(connectionsettings);
         connectionsettings.Address = Settings.PLCUri;
-        var typeConverter = new OpcTypeConverter();
 
         connection = new PlcConnection(MockHelpers.GetOptionsMoq(connectionsettings), MockHelpers.GetLoggerMock<PlcConnection>());
         symbolHandler = new SymbolHandler(connection, MockHelpers.GetLoggerMock<SymbolHandler>());
+        var typeConverter = new OpcTypeConverter(symbolHandler);
         readWrite = new ReadWrite(connection, symbolHandler, typeConverter, MockHelpers.GetLoggerMock<ReadWrite>());
         await connection.ConnectAsync();
         _ = await connection.GetConnectedClientAsync(TimeSpan.FromSeconds(1));


### PR DESCRIPTION
A rewrite of the type converter when creating objects or structs.
speeds up the object creation via expression tree's.
supports setting value's with the constructor
and via property setters.