### PR TITLE
Use IOpcSymbolInfo instead of concrete type

### DIFF
--- a/src/PlcInterface.OpcUa/Extensions/ISymbolInfoExtension.cs
+++ b/src/PlcInterface.OpcUa/Extensions/ISymbolInfoExtension.cs
@@ -9,16 +9,17 @@ namespace PlcInterface.OpcUa;
 internal static class ISymbolInfoExtension
 {
     /// <summary>
-    /// Convert the <see cref="ISymbolInfo"/> to <see cref="SymbolInfo"/> and throw a exception if the conversion fails.
+    /// Convert the <see cref="ISymbolInfo"/> to <see cref="IOpcSymbolInfo"/> and throw a exception
+    /// if the conversion fails.
     /// </summary>
     /// <param name="symbolInfo">The <see cref="ISymbolInfo"/> to change.</param>
     /// <returns>The cast object.</returns>
     /// <exception cref="SymbolException">If the cast fails.</exception>
-    public static SymbolInfo ConvertAndValidate(this ISymbolInfo symbolInfo)
+    public static IOpcSymbolInfo ConvertAndValidate(this ISymbolInfo symbolInfo)
     {
-        if (symbolInfo is not SymbolInfo symbol)
+        if (symbolInfo is not IOpcSymbolInfo symbol)
         {
-            throw new SymbolException($"symbol is not a {typeof(SymbolInfo)}");
+            throw new SymbolException($"symbol is not a {typeof(IOpcSymbolInfo)}");
         }
 
         return symbol;

--- a/src/PlcInterface.OpcUa/IOpcSymbolHandler.cs
+++ b/src/PlcInterface.OpcUa/IOpcSymbolHandler.cs
@@ -1,8 +1,24 @@
-﻿namespace PlcInterface.OpcUa;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace PlcInterface.OpcUa;
 
 /// <summary>
 /// The Opc implementation of a <see cref="ISymbolHandler"/>.
 /// </summary>
 public interface IOpcSymbolHandler : ISymbolHandler
 {
+    /// <summary>
+    /// Gets the <see cref="ISymbolInfo"/>.
+    /// </summary>
+    /// <param name="ioName">The tag name.</param>
+    /// <returns>The found <see cref="ISymbolInfo"/>.</returns>
+    new IOpcSymbolInfo GetSymbolinfo(string ioName);
+
+    /// <summary>
+    /// Try to get the <see cref="IOpcSymbolInfo"/>.
+    /// </summary>
+    /// <param name="ioName">The tag name.</param>
+    /// <param name="symbolInfo">The found <see cref="IOpcSymbolInfo"/>.</param>
+    /// <returns><see langword="true"/> when the symbol was found else <see langword="false"/>.</returns>
+    bool TryGetSymbolinfo(string ioName, [MaybeNullWhen(false)] out IOpcSymbolInfo symbolInfo);
 }

--- a/src/PlcInterface.OpcUa/IOpcSymbolInfo.cs
+++ b/src/PlcInterface.OpcUa/IOpcSymbolInfo.cs
@@ -1,0 +1,57 @@
+﻿using Opc.Ua;
+
+namespace PlcInterface.OpcUa;
+
+/// <summary>
+/// The OPC implementation of a <see cref="ISymbolInfo"/>.
+/// </summary>
+public interface IOpcSymbolInfo : ISymbolInfo
+{
+    /// <summary>
+    /// Gets the bounds of the array.
+    /// </summary>
+    int[] ArrayBounds
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets the built in type.
+    /// </summary>
+    BuiltInType BuiltInType
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets the PLC symbol this encapsules.
+    /// </summary>
+    NodeId Handle
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets the indices of this array item.
+    /// </summary>
+    int[] Indices
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether this symbol represents a array.
+    /// </summary>
+    bool IsArray
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether this symbol represents a complex type.
+    /// </summary>
+    bool IsBigType
+    {
+        get;
+    }
+}

--- a/src/PlcInterface.OpcUa/Monitor.cs
+++ b/src/PlcInterface.OpcUa/Monitor.cs
@@ -251,7 +251,7 @@ public class Monitor : IOpcMonitor, IDisposable
                 h => monitoredItem.Notification -= h)
                 .Select(x =>
                 {
-                    if (x.Sender?.Handle is SymbolInfo s
+                    if (x.Sender?.Handle is IOpcSymbolInfo s
                     && x.EventArgs.NotificationValue is MonitoredItemNotification datachange)
                     {
                         return new MonitorResult(s.Name, typeConverter.Convert(datachange.Value.Value));
@@ -268,11 +268,10 @@ public class Monitor : IOpcMonitor, IDisposable
         public void Dispose()
             => Dispose(disposing: true);
 
-        public void UpdateMonitoredItem(ISymbolHandler symbolHandler)
+        public void UpdateMonitoredItem(IOpcSymbolHandler symbolHandler)
         {
-            if (symbolHandler.TryGetSymbolinfo(name, out var symbol))
+            if (symbolHandler.TryGetSymbolinfo(name, out var symbolInfo))
             {
-                var symbolInfo = symbol.ConvertAndValidate();
                 MonitoredItem.StartNodeId = symbolInfo.Handle;
                 MonitoredItem.Handle = symbolInfo;
             }

--- a/src/PlcInterface.OpcUa/OpcTypeConverter.cs
+++ b/src/PlcInterface.OpcUa/OpcTypeConverter.cs
@@ -68,7 +68,7 @@ public sealed class OpcTypeConverter : TypeConverter, IOpcTypeConverter
     /// <inheritdoc/>
     public dynamic CreateDynamic(string symbolName, IEnumerator<DataValue> valueEnumerator)
     {
-        var symbolInfo = symbolHandler.GetSymbolinfo(symbolName).ConvertAndValidate();
+        var symbolInfo = symbolHandler.GetSymbolinfo(symbolName);
         return CreateDynamic(symbolInfo, valueEnumerator);
     }
 
@@ -84,7 +84,7 @@ public sealed class OpcTypeConverter : TypeConverter, IOpcTypeConverter
         return TimeSpan.FromMilliseconds(miliSeconds);
     }
 
-    private dynamic CreateDynamic(SymbolInfo symbolInfo, IEnumerator<DataValue> valueEnumerator)
+    private dynamic CreateDynamic(IOpcSymbolInfo symbolInfo, IEnumerator<DataValue> valueEnumerator)
     {
         if (symbolInfo.ChildSymbols.Count == 0)
         {
@@ -99,7 +99,7 @@ public sealed class OpcTypeConverter : TypeConverter, IOpcTypeConverter
             var array = Array.CreateInstance(typeof(object), symbolInfo.ArrayBounds);
             foreach (var childSymbolName in symbolInfo.ChildSymbols)
             {
-                var childSymbolInfo = symbolHandler.GetSymbolinfo(childSymbolName).ConvertAndValidate();
+                var childSymbolInfo = symbolHandler.GetSymbolinfo(childSymbolName);
                 var value = CreateDynamic(childSymbolInfo, valueEnumerator);
                 var indices = childSymbolInfo.Indices;
                 array.SetValue(value, indices);
@@ -111,7 +111,7 @@ public sealed class OpcTypeConverter : TypeConverter, IOpcTypeConverter
         var collection = new ExpandoObject() as IDictionary<string, object>;
         foreach (var childSymbolName in symbolInfo.ChildSymbols)
         {
-            var childSymbolInfo = symbolHandler.GetSymbolinfo(childSymbolName).ConvertAndValidate();
+            var childSymbolInfo = symbolHandler.GetSymbolinfo(childSymbolName);
             var value = CreateDynamic(childSymbolInfo, valueEnumerator);
             var shortName = childSymbolInfo.ShortName;
             collection.Add(shortName, value);

--- a/src/PlcInterface.OpcUa/ReadWrite.cs
+++ b/src/PlcInterface.OpcUa/ReadWrite.cs
@@ -50,8 +50,8 @@ public class ReadWrite : IOpcReadWrite, IDisposable
     {
         var nodesToRead = ioNames
           .SelectMany(x => symbolHandler.GetSymbolinfo(x).Flatten(symbolHandler))
-          .Where(x => x.ChildSymbols.Count == 0 && x is SymbolInfo)
-          .Cast<SymbolInfo>()
+          .Where(x => x.ChildSymbols.Count == 0 && x is IOpcSymbolInfo)
+          .Cast<IOpcSymbolInfo>()
           .Select(x => x.Handle)
           .ToList();
 
@@ -78,7 +78,7 @@ public class ReadWrite : IOpcReadWrite, IDisposable
     /// <inheritdoc/>
     public object Read(string ioName)
     {
-        var symbol = symbolHandler.GetSymbolinfo(ioName).ConvertAndValidate();
+        var symbol = symbolHandler.GetSymbolinfo(ioName);
         if (symbol.ChildSymbols.Count > 0)
         {
             return ReadDynamic(ioName);
@@ -95,8 +95,8 @@ public class ReadWrite : IOpcReadWrite, IDisposable
     {
         var nodesToRead = ioNames
             .SelectMany(x => symbolHandler.GetSymbolinfo(x).Flatten(symbolHandler))
-            .Where(x => x.ChildSymbols.Count == 0 && x is SymbolInfo)
-            .Cast<SymbolInfo>()
+            .Where(x => x.ChildSymbols.Count == 0 && x is IOpcSymbolInfo)
+            .Cast<IOpcSymbolInfo>()
             .Select(x => x.Handle)
             .ToList();
 
@@ -116,7 +116,7 @@ public class ReadWrite : IOpcReadWrite, IDisposable
     /// <inheritdoc/>
     public async Task<object> ReadAsync(string ioName)
     {
-        var symbol = symbolHandler.GetSymbolinfo(ioName).ConvertAndValidate();
+        var symbol = symbolHandler.GetSymbolinfo(ioName);
         if (symbol.ChildSymbols.Count > 0)
         {
             return await ReadDynamicAsync(ioName).ConfigureAwait(false);

--- a/src/PlcInterface.OpcUa/SymbolHandler.cs
+++ b/src/PlcInterface.OpcUa/SymbolHandler.cs
@@ -57,18 +57,30 @@ public class SymbolHandler : IOpcSymbolHandler, IDisposable
     }
 
     /// <inheritdoc/>
-    public ISymbolInfo GetSymbolinfo(string ioName)
+    ISymbolInfo ISymbolHandler.GetSymbolinfo(string ioName)
+        => GetSymbolinfo(ioName);
+
+    /// <inheritdoc/>
+    public IOpcSymbolInfo GetSymbolinfo(string ioName)
     {
         if (TryGetSymbolinfo(ioName, out var symbolInfo) && symbolInfo != null)
         {
             return symbolInfo;
         }
 
-        throw new SymbolException($"{ioName} Does not excist in the PLC");
+        throw new SymbolException($"{ioName} Does not exist in the PLC");
     }
 
     /// <inheritdoc/>
-    public bool TryGetSymbolinfo(string ioName, [MaybeNullWhen(false)] out ISymbolInfo symbolInfo)
+    bool ISymbolHandler.TryGetSymbolinfo(string ioName, [MaybeNullWhen(false)] out ISymbolInfo symbolInfo)
+    {
+        var result = TryGetSymbolinfo(ioName, out var symbolInfoResult);
+        symbolInfo = symbolInfoResult;
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetSymbolinfo(string ioName, [MaybeNullWhen(false)] out IOpcSymbolInfo symbolInfo)
     {
         if (allSymbols.TryGetValue(ioName.ToLower(CultureInfo.InvariantCulture), out var symbolInfoResult))
         {
@@ -76,7 +88,7 @@ public class SymbolHandler : IOpcSymbolHandler, IDisposable
             return true;
         }
 
-        logger.LogError("{IoName} Does not excist in the PLC", ioName);
+        logger.LogError("{IoName} Does not exist in the PLC", ioName);
         symbolInfo = null;
         return false;
     }

--- a/src/PlcInterface.OpcUa/SymbolHandler.cs
+++ b/src/PlcInterface.OpcUa/SymbolHandler.cs
@@ -17,7 +17,7 @@ public class SymbolHandler : IOpcSymbolHandler, IDisposable
     private readonly IOpcPlcConnection connection;
     private readonly CompositeDisposable disposables = new();
     private readonly ILogger logger;
-    private IDictionary<string, SymbolInfo> allSymbols = new Dictionary<string, SymbolInfo>(StringComparer.OrdinalIgnoreCase);
+    private IDictionary<string, IOpcSymbolInfo> allSymbols = new Dictionary<string, IOpcSymbolInfo>(StringComparer.OrdinalIgnoreCase);
     private bool disposedValue;
     private ISession? session;
 

--- a/src/PlcInterface.OpcUa/SymbolInfo.cs
+++ b/src/PlcInterface.OpcUa/SymbolInfo.cs
@@ -11,7 +11,7 @@ namespace PlcInterface.OpcUa;
 /// Stores data about a PLC symbol.
 /// </summary>
 [DebuggerDisplay("{Name}")]
-internal sealed class SymbolInfo : ISymbolInfo
+internal sealed class SymbolInfo : IOpcSymbolInfo
 {
     private readonly Lazy<int[]> arrayBounds;
     private readonly NodeInfo nodeInfo;
@@ -36,15 +36,11 @@ internal sealed class SymbolInfo : ISymbolInfo
         Comment = string.Empty;
     }
 
-    /// <summary>
-    /// Gets the bounds of the array.
-    /// </summary>
+    /// <inheritdoc/>
     public int[] ArrayBounds
         => arrayBounds.Value;
 
-    /// <summary>
-    /// Gets the builtin type.
-    /// </summary>
+    /// <inheritdoc/>
     public BuiltInType BuiltInType
         => nodeInfo.BuiltInType;
 
@@ -60,31 +56,23 @@ internal sealed class SymbolInfo : ISymbolInfo
         get;
     }
 
-    /// <summary>
-    /// Gets the PLC symbol this encapsules.
-    /// </summary>
+    /// <inheritdoc/>
     public NodeId Handle
     {
         get;
     }
 
-    /// <summary>
-    /// Gets the indices of this array item.
-    /// </summary>
+    /// <inheritdoc/>
     public int[] Indices
     {
         get;
     }
 
-    /// <summary>
-    /// Gets a value indicating whether this symbol represents a array.
-    /// </summary>
+    /// <inheritdoc/>
     public bool IsArray
         => ChildSymbols.Count > 0 && ChildSymbols[0].AsSpan(Name.Length).IndexOf('[') != -1;
 
-    /// <summary>
-    /// Gets a value indicating whether this symbol represents a complex type.
-    /// </summary>
+    /// <inheritdoc/>
     public bool IsBigType
     {
         get;

--- a/src/PlcInterface.OpcUa/TreeBrowser.cs
+++ b/src/PlcInterface.OpcUa/TreeBrowser.cs
@@ -32,7 +32,7 @@ internal sealed class TreeBrowser : Browser
     /// <summary>
     /// Browses the specified symbols.
     /// </summary>
-    /// <param name="nodes">A <see cref="IEnumerable{T}"/> of <see cref="SymbolInfo"/> to browse.</param>
+    /// <param name="nodes">A <see cref="IEnumerable{T}"/> of <see cref="NodeId"/> to browse.</param>
     /// <returns>A <see cref="IDictionary{TKey, TValue}"/> with the browse result for every symbol.</returns>
     public IEnumerable<ReferenceDescriptionCollection> Browse(IEnumerable<NodeId> nodes)
     {
@@ -68,7 +68,7 @@ internal sealed class TreeBrowser : Browser
     /// </summary>
     /// <param name="address">The adress to start the tree at.</param>
     /// <returns>All found symbols on the server.</returns>
-    public IDictionary<string, SymbolInfo> BrowseTree(Uri address)
+    public IDictionary<string, IOpcSymbolInfo> BrowseTree(Uri address)
     {
         var path = address.AbsolutePath.Trim('/').Replace("%20", " ", StringComparison.OrdinalIgnoreCase);
         var rootNode = CreateRootNodeSymbol(path);
@@ -90,7 +90,7 @@ internal sealed class TreeBrowser : Browser
         return uri.Replace(rootName, string.Empty, StringComparison.OrdinalIgnoreCase).Trim(splitChar);
     }
 
-    private static SymbolInfo CreateSymbol(ReferenceDescription description, NodeInfo nodeInfo, SymbolInfo? parent, string rootName)
+    private static IOpcSymbolInfo CreateSymbol(ReferenceDescription description, NodeInfo nodeInfo, IOpcSymbolInfo? parent, string rootName)
     {
         var nameBuilder = new StringBuilder();
         var parentName = parent == null ? ReadOnlySpan<char>.Empty : parent.Name.AsSpan();
@@ -174,7 +174,7 @@ internal sealed class TreeBrowser : Browser
         return results[0].References;
     }
 
-    private IEnumerable<SymbolInfo> BrowseRecursive(IEnumerable<SymbolInfo> symbols, string rootName)
+    private IEnumerable<IOpcSymbolInfo> BrowseRecursive(IEnumerable<IOpcSymbolInfo> symbols, string rootName)
     {
         var browseResult = Browse(symbols.Select(x => x.Handle)).ToList();
         var nodeInfos = browseResult
@@ -193,13 +193,13 @@ internal sealed class TreeBrowser : Browser
 
         if (allSymbols.Count <= 0)
         {
-            return Enumerable.Empty<SymbolInfo>();
+            return Enumerable.Empty<IOpcSymbolInfo>();
         }
 
         return allSymbols.Concat(allSymbols.Chunk((int)operationLimits.MaxNodesPerBrowse).SelectMany(x => BrowseRecursive(x, rootName)));
     }
 
-    private SymbolInfo CreateRootNodeSymbol(string path)
+    private IOpcSymbolInfo CreateRootNodeSymbol(string path)
     {
         var lastNode = new ReferenceDescription() { NodeId = ObjectIds.ObjectsFolder, NodeClass = NodeClass.Object, BrowseName = string.Empty };
         var rootNodeName = string.Empty;

--- a/test/PlcInterface.OpcUa.Tests/ISymbolInfoExtensionTests.cs
+++ b/test/PlcInterface.OpcUa.Tests/ISymbolInfoExtensionTests.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace PlcInterface.OpcUa.Tests;
+
+[TestClass]
+public class ISymbolInfoExtensionTests
+{
+    [TestMethod]
+    public void CastAndValidateReturnsSymbolInfo()
+    {
+        // Arrange
+        ISymbolInfo symbolInfo = Mock.Of<IOpcSymbolInfo>();
+
+        // Act
+        var actual = symbolInfo.ConvertAndValidate();
+
+        // Assert
+        Assert.IsInstanceOfType(actual, typeof(IOpcSymbolInfo));
+        Assert.IsInstanceOfType(actual, typeof(ISymbolInfo));
+        Assert.AreSame(symbolInfo, actual);
+    }
+
+    [TestMethod]
+    public void CastAndValidateThrowsSymbolExceptionWhenNotAdsSymbol()
+    {
+        // Arrange
+        var symbolMock = Mock.Of<ISymbolInfo>();
+
+        // Act Assert
+        _ = Assert.ThrowsException<SymbolException>(symbolMock.ConvertAndValidate);
+    }
+}


### PR DESCRIPTION
Replace all uses of ISymbolInfo with IOpcSymbolInfo
to make it work like the ADS counterpart